### PR TITLE
Fix interrupt line to act as level triggered.

### DIFF
--- a/main.c
+++ b/main.c
@@ -355,14 +355,11 @@ void update_interrupts()
   A1 - D2
   A2 - D8
   */
-  if (!GS)
-  {
-    // z80_gen_int(&cpu, (Q0 << 6) | (Q1 << 1) | (Q2 << 7));
-    z80_gen_int(&cpu, psg_portb & 0x0e);
-    // z80_gen_int(&cpu, prev_int_line);
-    // prev_int_line = (Q0 << 5) | (Q1 << 6) | (Q2 << 7);
-    // z80_gen_int(&cpu, !GS);
-  }
+  // z80_gen_int(&cpu, (Q0 << 6) | (Q1 << 1) | (Q2 << 7));
+  z80_gen_int(&cpu, !GS, psg_portb & 0x0e);
+  // z80_gen_int(&cpu, prev_int_line);
+  // prev_int_line = (Q0 << 5) | (Q1 << 6) | (Q2 << 7);
+  // z80_gen_int(&cpu, !GS);
 }
 
 char keyboard_buffer[256];

--- a/z80.c
+++ b/z80.c
@@ -689,7 +689,6 @@ static inline void process_interrupts(z80* const z) {
   }
 
   if (z->int_pending && z->iff1) {
-    z->int_pending = 0;
     z->halted = 0;
     z->iff1 = 0;
     z->iff2 = 0;
@@ -708,7 +707,6 @@ static inline void process_interrupts(z80* const z) {
 
     case 2:
       z->cyc += 19;
-      if((rw(z, (z->i << 8) | z->int_data)) == 0) break; /* HACK */
       call(z, rw(z, (z->i << 8) | z->int_data));
       break;
 
@@ -809,8 +807,8 @@ void z80_gen_nmi(z80* const z) {
 }
 
 /* function to call when an INT is to be serviced */
-void z80_gen_int(z80* const z, uint8_t data) {
-  z->int_pending = 1;
+void z80_gen_int(z80* const z, uint8_t state, uint8_t data) {
+  z->int_pending = state;
   z->int_data = data;
 }
 

--- a/z80.h
+++ b/z80.h
@@ -57,6 +57,6 @@ void z80_init(z80* const z);
 void z80_step(z80* const z);
 void z80_debug_output(z80* const z);
 void z80_gen_nmi(z80* const z);
-void z80_gen_int(z80* const z, uint8_t data);
+void z80_gen_int(z80* const z, uint8_t state, uint8_t data);
 
 #endif /* Z80_Z80_H_ */


### PR DESCRIPTION
This fixes your z80 interrupt line to be level triggered, it will go high when the encoder's GS line is low and will remain as such until the GS line goes high. 

It also seems to fix the unexpected interrupt issue you were having that causes cloud CP/M to hang.